### PR TITLE
Generate OSGi metadata into apfloat jars to make it OSGi compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ If you have any questions or need a different type of license, please [contact t
 
 ## Building the Library
 
+To build the library quickly, without running unit tests (takes about 10 minutes) and without signing with GPG run:
+
+`mvn clean install -Dgpg.skip -Djarsigner.skip -DskipTests`
+
 To build the signed applet files, you need to first generate a signing key, e.g. with:
 
 `keytool -genkeypair -validity 21915 -dname "cn=Your Name, o=example.com" -storepass password -keypass password -alias mykey`
 
-To build the library quickly, without running unit tests (takes about 10 minutes) and without signing with GPG run:
-
-`mvn clean install -Dgpg.skip=true -DskipTests=true`
+and then build without -Djarsigner.skip.
 
 ## Running the Sample Applications
 

--- a/apfloat-aparapi/pom.xml
+++ b/apfloat-aparapi/pom.xml
@@ -42,13 +42,23 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-osgi-manifest</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>org.apfloat.aparapi</Automatic-Module-Name>
-            </manifestEntries>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/apfloat-calc/pom.xml
+++ b/apfloat-calc/pom.xml
@@ -47,17 +47,28 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-osgi-manifest</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+            <configuration>
+              <bnd><![CDATA[
+                Main-Class: org.apfloat.calc.CalculatorGUI
+              ]]></bnd>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifest>
-              <addClasspath>true</addClasspath>
-              <mainClass>org.apfloat.calc.CalculatorGUI</mainClass>
-            </manifest>
-            <manifestEntries>
-              <Automatic-Module-Name>org.apfloat.calc</Automatic-Module-Name>
-            </manifestEntries>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/apfloat-jscience/pom.xml
+++ b/apfloat-jscience/pom.xml
@@ -42,13 +42,23 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-osgi-manifest</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>org.apfloat.jscience</Automatic-Module-Name>
-            </manifestEntries>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/apfloat/pom.xml
+++ b/apfloat/pom.xml
@@ -201,6 +201,24 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>biz.aQute.bnd</groupId>
+        <artifactId>bnd-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-osgi-manifest</id>
+            <goals>
+              <goal>bnd-process</goal>
+            </goals>
+            <configuration>
+              <bnd><![CDATA[
+                DynamicImport-Package: org.apfloat.aparapi
+                Multi-Release: true
+              ]]></bnd>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
@@ -212,10 +230,7 @@
         </executions>
         <configuration>
           <archive>
-            <manifestEntries>
-              <Automatic-Module-Name>org.apfloat</Automatic-Module-Name>
-              <Multi-Release>true</Multi-Release>
-            </manifestEntries>
+            <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,27 @@
           <version>3.3.0</version>
         </plugin>
         <plugin>
+          <groupId>biz.aQute.bnd</groupId>
+          <artifactId>bnd-maven-plugin</artifactId>
+          <version>7.0.0</version>
+          <executions>
+            <execution>
+              <id>generate-osgi-manifest</id>
+              <goals>
+                <goal>bnd-process</goal>
+              </goals>
+              <configuration>
+                <bnd><![CDATA[
+                  Bundle-SymbolicName: org.$[replacestring;${project.artifactId};-;.]
+                  Automatic-Module-Name: $[bsn]
+                  -exportcontents: *;-noimport:=true
+                  -noextraheaders: true
+                ]]></bnd>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.3.0</version>


### PR DESCRIPTION
This allows usage of the following modules in an OSGi runtime out of the box:
- `apfloat`
- `apfloat-aparapi`
- `apfloat-jscience`

All OSGi metadata are generated at build-time using the [bnd-maven-plugin](https://github.com/bndtools/bnd/tree/master/maven-plugins/bnd-maven-plugin) provided by [bndtools](https://bnd.bndtools.org/).

Additionally let the bnd-maven-plugin generate the services file for the apfloat module together with corresponding OSGi metadata to make service usage work in OSGi runtimes. In order to make this work add a _compile-time only_ dependency to ['biz.aQute.bnd:biz.aQute.bnd.annotation:7.0.0'](https://mvnrepository.com/artifact/biz.aQute.bnd/biz.aQute.bnd.annotation/7.0.0).

In case you are interested in having the module-info.java for the Java Platform Module System generated as well, this could also be generated using the bnd-maven-plugin:
https://bnd.bndtools.org/chapters/330-jpms.html

Last but not least, this PR fixes and shortens the build instructions in the Readme, `jarsigner.skip` is the property to skip signing and not `gpg.skip`.
